### PR TITLE
Refactor Jobinfo

### DIFF
--- a/examples/spitz-pi-2/main.cpp
+++ b/examples/spitz-pi-2/main.cpp
@@ -3,22 +3,22 @@
  *
  * Copyright (c) 2016 Caian Benedicto <caian@ggaunicamp.com>
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy 
- * of this software and associated documentation files (the "Software"), to 
- * deal in the Software without restriction, including without limitation the 
- * rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in 
+ *
+ * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
 
@@ -27,7 +27,7 @@
 // only once per C++ module.
 #define SPITZ_ENTRY_POINT
 
-// Spitz serial debug enables a Spitz-compliant main function to allow 
+// Spitz serial debug enables a Spitz-compliant main function to allow
 // the module to run as an executable for testing purposes.
 // #define SPITZ_SERIAL_DEBUG
 
@@ -40,9 +40,9 @@
 #include <vector>
 #include <cmath>
 
-// Parameters should not be stored inside global variables because the 
-// Spitz interface does not guarantee memory isolation between job 
-// manager, committer and workers. This can lead to a race condition when 
+// Parameters should not be stored inside global variables because the
+// Spitz interface does not guarantee memory isolation between job
+// manager, committer and workers. This can lead to a race condition when
 // each thread tries to initialize the parameters from argc and argv.
 struct parameters
 {
@@ -50,24 +50,24 @@ struct parameters
 
     int n;
     double step;
-    
+
     int split;
-    
-    parameters(int argc, const char *argv[], const std::string& who = "") : 
+
+    parameters(int argc, const char *argv[], const std::string& who = "") :
         split(1000), who(who)
     {
         if (argc < 2 || argc > 3) {
             std::cerr << "USAGE: " << argv[0] << " N" << std::endl;
             exit(1);
         }
-        
+
         n = atoi(argv[1]);
         step = 1.0 / (double)n;
     }
-    
+
     void print()
     {
-        std::cout 
+        std::cout
             << who << "N: " << n << std::endl
             << who << "step: " << step << std::endl;
     }
@@ -85,7 +85,7 @@ public:
         double pi_1, pi_2, pi_err;
         int r;
 
-        // Let's do two steps: Compute pi with the provided number of 
+        // Let's do two steps: Compute pi with the provided number of
         // iteractions and then halving the number of iteractions
 
         std::stringstream ss;
@@ -112,7 +112,7 @@ public:
             exit(1);
         }
 
-        // We know the passed data is a double, 
+        // We know the passed data is a double,
         // collect the first value of pi
         final_result >> pi_1;
 
@@ -126,7 +126,7 @@ public:
             exit(1);
         }
 
-        // We know the passed data is a double, 
+        // We know the passed data is a double,
         // collect the second value of pi
         final_result >> pi_2;
 
@@ -134,11 +134,11 @@ public:
         pi_err = std::abs(pi_2 - pi_1);
 
         std::cout.precision(17);
-        std::cout << "[SM] First pi value is: " << std::fixed 
+        std::cout << "[SM] First pi value is: " << std::fixed
             << pi_1 << std::endl
-            << "[SM] Second pi value is: " << std::fixed 
+            << "[SM] Second pi value is: " << std::fixed
             << pi_2 << std::endl
-            << "[SM] The error is: " << std::fixed 
+            << "[SM] The error is: " << std::fixed
             << pi_err << std::endl;
 
         return 0;
@@ -151,37 +151,37 @@ class job_manager : public spitz::job_manager
 private:
     parameters p;
     int i;
-    
+
 public:
-    job_manager(int argc, const char *argv[], spitz::istream& jobinfo) : 
+    job_manager(int argc, const char *argv[], spitz::istream& jobinfo) :
         p(argc, argv, "[JM] "), i(0)
     {
         p.print();
-        
+
         std::cout << "[JM] Job manager created." << std::endl;
     }
-    
+
     bool next_task(const spitz::pusher& task)
     {
         spitz::ostream o;
-        
+
         if (i >= p.n)
             return false;
-        
+
         // Push the current step
         o << i;
 
         std::cout << "[JM] Generated task for i = " << i << "." << std::endl;
-        
+
         // Increment the step by the amount to be packed for each worker
         i += p.split;
-        
+
         // Serialize and push the task
         task.push(o);
-        
+
         return true;
     }
-    
+
     ~job_manager()
     {
     }
@@ -189,33 +189,33 @@ public:
 
 // This class executes tasks, preferably without modifying its internal state
 // because this can lead to a break of idempotence between tasks. The 'run'
-// method will not impose a 'const' behavior to allow libraries that rely 
+// method will not impose a 'const' behavior to allow libraries that rely
 // on changing its internal state, for instance, OpenCL (see clpi example).
 class worker : public spitz::worker
 {
 private:
     parameters p;
-    
+
 public:
     worker(int argc, const char *argv[]) : p(argc, argv, "[WK] ")
     {
         p.print();
         std::cout << "[WK] Worker created." << std::endl;
     }
-    
+
     int run(spitz::istream& task, const spitz::pusher& result)
     {
         // Data stream used to store the output
         spitz::ostream o;
-        
+
         // Read the current step from the task
         int i, batch;
         task >> i;
         batch = i;
-        
+
         // Get the number of steps to compute
         int n = std::min<int>(p.n, i + p.split);
-        
+
         // Compute each term of the pi expansion
         for ( ; i < n; i++) {
             double x = (static_cast<double>(i) + 0.5) * p.step;
@@ -223,56 +223,56 @@ public:
             // Add the term to the data stream
             o << x;
         }
-        
+
         // Send the result to the Spitz runtime
         result.push(o);
-        
-        std::cout << "[WK] Processed  batch " << batch << "." << std::endl;
+
+        std::cout << "[WK] Processed batch " << batch << "." << std::endl;
         return 0;
     }
 };
 
-// This class is responsible for merging the result of each individual task 
-// and, if necessary, to produce the final result after all of the task 
+// This class is responsible for merging the result of each individual task
+// and, if necessary, to produce the final result after all of the task
 // results have been received.
 class committer : public spitz::committer
 {
 private:
     parameters p;
     double pival;
-    
+
 public:
-    committer(int argc, const char *argv[], spitz::istream& jobinfo) : 
+    committer(int argc, const char *argv[], spitz::istream& jobinfo) :
         p(argc, argv, "[CO] "), pival(0.0)
     {
         p.print();
         std::cout << "[CO] Committer created." << std::endl;
     }
-    
+
     int commit_task(spitz::istream& result)
     {
         std::cout << "[CO] Committing result..." << std::endl;
-        
+
         // Accumulate each term of the expansion
         while(result.has_data()) {
             double d;
             result >> d;
             pival += d;
         }
-        
+
         return 0;
     }
-    
-    int commit_job(const spitz::pusher& final_result) 
+
+    int commit_job(const spitz::pusher& final_result)
     {
         // Our result stream
         spitz::ostream o;
 
-        // Multiply the sum of terms by the step to get the 
-        // final result of pi and print it with the maximum 
+        // Multiply the sum of terms by the step to get the
+        // final result of pi and print it with the maximum
         // precision possible
         pival = pival * p.step;
-        
+
         // Push the result
         o << pival;
         final_result.push(o);
@@ -281,7 +281,7 @@ public:
 
     ~committer()
     {
-        
+
     }
 };
 
@@ -294,18 +294,18 @@ public:
         return new spitz_main();
     }
 
-    spitz::job_manager *create_job_manager(int argc, const char *argv[], 
+    spitz::job_manager *create_job_manager(int argc, const char *argv[],
         spitz::istream& jobinfo)
     {
         return new job_manager(argc, argv, jobinfo);
     }
-    
+
     spitz::worker *create_worker(int argc, const char *argv[])
     {
         return new worker(argc, argv);
     }
-    
-    spitz::committer *create_committer(int argc, const char *argv[], 
+
+    spitz::committer *create_committer(int argc, const char *argv[],
         spitz::istream& jobinfo)
     {
         return new committer(argc, argv, jobinfo);

--- a/examples/spitz-pi/main.cpp
+++ b/examples/spitz-pi/main.cpp
@@ -3,22 +3,22 @@
  *
  * Copyright (c) 2016 Caian Benedicto <caian@ggaunicamp.com>
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy 
- * of this software and associated documentation files (the "Software"), to 
- * deal in the Software without restriction, including without limitation the 
- * rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in 
+ *
+ * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
 
@@ -27,7 +27,7 @@
 // only once per C++ module.
 #define SPITZ_ENTRY_POINT
 
-// Spitz serial debug enables a Spitz-compliant main function to allow 
+// Spitz serial debug enables a Spitz-compliant main function to allow
 // the module to run as an executable for testing purposes.
 // #define SPITZ_SERIAL_DEBUG
 
@@ -37,9 +37,9 @@
 #include <string>
 #include <limits>
 
-// Parameters should not be stored inside global variables because the 
-// Spitz interface does not guarantee memory isolation between job 
-// manager, committer and workers. This can lead to a race condition when 
+// Parameters should not be stored inside global variables because the
+// Spitz interface does not guarantee memory isolation between job
+// manager, committer and workers. This can lead to a race condition when
 // each thread tries to initialize the parameters from argc and argv.
 struct parameters
 {
@@ -47,24 +47,24 @@ struct parameters
 
     int n;
     double step;
-    
+
     int split;
-    
-    parameters(int argc, const char *argv[], const std::string& who = "") : 
+
+    parameters(int argc, const char *argv[], const std::string& who = "") :
         split(1000), who(who)
     {
         if (argc < 2 || argc > 3) {
             std::cerr << "USAGE: " << argv[0] << " N" << std::endl;
             exit(1);
         }
-        
+
         n = atoi(argv[1]);
         step = 1.0 / (double)n;
     }
-    
+
     void print()
     {
-        std::cout 
+        std::cout
             << who << "N: " << n << std::endl
             << who << "step: " << step << std::endl;
     }
@@ -76,37 +76,37 @@ class job_manager : public spitz::job_manager
 private:
     parameters p;
     int i;
-    
+
 public:
-    job_manager(int argc, const char *argv[], spitz::istream& jobinfo) : 
+    job_manager(int argc, const char *argv[], spitz::istream& jobinfo) :
         p(argc, argv, "[JM] "), i(0)
     {
         p.print();
-        
+
         std::cout << "[JM] Job manager created." << std::endl;
     }
-    
+
     bool next_task(const spitz::pusher& task)
     {
         spitz::ostream o;
-        
+
         if (i >= p.n)
             return false;
-        
+
         // Push the current step
         o << i;
-        
+
         // Increment the step by the amount to be packed for each worker
         i += p.split;
 
         std::cout << "[JM] Generated task for i = " << i << "." << std::endl;
-        
+
         // Serialize and push the task
         task.push(o);
-        
+
         return true;
     }
-    
+
     ~job_manager()
     {
     }
@@ -114,33 +114,33 @@ public:
 
 // This class executes tasks, preferably without modifying its internal state
 // because this can lead to a break of idempotence between tasks. The 'run'
-// method will not impose a 'const' behavior to allow libraries that rely 
+// method will not impose a 'const' behavior to allow libraries that rely
 // on changing its internal state, for instance, OpenCL (see clpi example).
 class worker : public spitz::worker
 {
 private:
     parameters p;
-    
+
 public:
     worker(int argc, const char *argv[]) : p(argc, argv, "[WK] ")
     {
         p.print();
         std::cout << "[WK] Worker created." << std::endl;
     }
-    
+
     int run(spitz::istream& task, const spitz::pusher& result)
     {
         // Data stream used to store the output
         spitz::ostream o;
-        
+
         // Read the current step from the task
         int i, batch;
         task >> i;
         batch = i;
-        
+
         // Get the number of steps to compute
         int n = std::min<int>(p.n, i + p.split);
-        
+
         // Compute each term of the pi expansion
         for ( ; i < n; i++) {
             double x = (static_cast<double>(i) + 0.5) * p.step;
@@ -148,56 +148,56 @@ public:
             // Add the term to the data stream
             o << x;
         }
-        
+
         // Send the result to the Spitz runtime
         result.push(o);
-        
-        std::cout << "[WK] Processed  batch " << batch << "." << std::endl;
+
+        std::cout << "[WK] Processed batch " << batch << "." << std::endl;
         return 0;
     }
 };
 
-// This class is responsible for merging the result of each individual task 
-// and, if necessary, to produce the final result after all of the task 
+// This class is responsible for merging the result of each individual task
+// and, if necessary, to produce the final result after all of the task
 // results have been received.
 class committer : public spitz::committer
 {
 private:
     parameters p;
     double pival;
-    
+
 public:
-    committer(int argc, const char *argv[], spitz::istream& jobinfo) : 
+    committer(int argc, const char *argv[], spitz::istream& jobinfo) :
         p(argc, argv, "[CO] "), pival(0.0)
     {
         p.print();
         std::cout << "[CO] Committer created." << std::endl;
     }
-    
+
     int commit_task(spitz::istream& result)
     {
         std::cout << "[CO] Committing result..." << std::endl;
-        
+
         // Accumulate each term of the expansion
         while(result.has_data()) {
             double d;
             result >> d;
             pival += d;
         }
-        
+
         return 0;
     }
-    
-    int commit_job(const spitz::pusher& final_result) 
+
+    int commit_job(const spitz::pusher& final_result)
     {
-        // Multiply the sum of terms by the step to get the 
-        // final result of pi and print it with the maximum 
+        // Multiply the sum of terms by the step to get the
+        // final result of pi and print it with the maximum
         // precision possible
         pival = pival * p.step;
         std::cout.precision(17);
-        std::cout << "[CO] The value of pi is: " << std::fixed 
+        std::cout << "[CO] The value of pi is: " << std::fixed
             << pival << std::endl;
-        
+
         // A result must be pushed even if it is an empty one
         final_result.push(NULL, 0);
         return 0;
@@ -205,7 +205,7 @@ public:
 
     ~committer()
     {
-        
+
     }
 };
 
@@ -213,18 +213,18 @@ public:
 class factory : public spitz::factory
 {
 public:
-    spitz::job_manager *create_job_manager(int argc, const char *argv[], 
+    spitz::job_manager *create_job_manager(int argc, const char *argv[],
         spitz::istream& jobinfo)
     {
         return new job_manager(argc, argv, jobinfo);
     }
-    
+
     spitz::worker *create_worker(int argc, const char *argv[])
     {
         return new worker(argc, argv);
     }
-    
-    spitz::committer *create_committer(int argc, const char *argv[], 
+
+    spitz::committer *create_committer(int argc, const char *argv[],
         spitz::istream& jobinfo)
     {
         return new committer(argc, argv, jobinfo);

--- a/spitz-include/ccpp/spitz/spitz.hpp
+++ b/spitz-include/ccpp/spitz/spitz.hpp
@@ -4,22 +4,22 @@
  * Copyright (c) 2015 Caian Benedicto <caian@ggaunicamp.com>
  * Copyright (c) 2014 Ian Liu Rodrigues <ian.liu@ggaunicamp.com>
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy 
- * of this software and associated documentation files (the "Software"), to 
- * deal in the Software without restriction, including without limitation the 
- * rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in 
+ *
+ * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
 
@@ -29,74 +29,76 @@
 #include "spitz.h"
 #include "stream.hpp"
 
+#include <iostream>
+
 namespace spitz {
-    
+
     class pusher
     {
     private:
         spitspush_t pushf;
         spitsctx_t ctx;
-        
+
     public:
-        pusher(spitspush_t pushf, spitsctx_t ctx) : 
+        pusher(spitspush_t pushf, spitsctx_t ctx) :
             pushf(pushf), ctx(ctx)
         {
         }
-        
+
         void push(const ostream& p) const
         {
             this->pushf(p.data(), p.pos(), this->ctx);
         }
-        
+
         void push(const void* p, spitssize_t s) const
         {
             this->pushf(p, s, this->ctx);
         }
     };
-    
+
     class runner
     {
     private:
         spitzrun_t runf;
-        
+
     public:
         runner(spitzrun_t runf) : runf(runf)
         {
         }
-        
+
         int run(int argc, const char** argv) const
         {
             ostream j;
             istream r;
             return run(argc, argv, j, r);
         }
-        
+
         int run(int argc, const char** argv, istream& final_result) const
         {
             ostream j;
             return run(argc, argv, j, final_result);
         }
-        
+
         int run(int argc, const char** argv, ostream& jobinfo) const
         {
             istream r;
             return run(argc, argv, jobinfo, r);
         }
 
-        int run(int argc, const char** argv, ostream& jobinfo, 
+        int run(int argc, const char** argv, ostream& jobinfo,
             istream& final_result) const
         {
             const void* pfinal_result;
             spitssize_t pfinal_result_size;
             const void* pjobinfo = jobinfo.data();
             spitssize_t pjobinfo_size = jobinfo.pos();
-            int r = this->runf(argc, argv, pjobinfo, pjobinfo_size, 
+            int r = this->runf(argc, argv, pjobinfo, pjobinfo_size,
                 &pfinal_result, &pfinal_result_size);
             final_result = istream(pfinal_result, pfinal_result_size);
             return r;
         }
     };
-    
+
     class spitz_main
     {
     public:
@@ -106,7 +108,7 @@ namespace spitz {
         }
         virtual ~spitz_main(){ }
     };
-    
+
     class job_manager
     {
     public:
@@ -150,11 +152,11 @@ extern "C" int spits_main(int argc, const char* argv[], spitzrun_t run)
 {
     spitz::spitz_main *sm = spitz_factory->create_spitz_main();
     spitz::runner runner(run);
-    
+
     int r = sm->main(argc, argv, runner);
-    
+
     delete sm;
-    
+
     return r;
 }
 
@@ -166,12 +168,12 @@ extern "C" void *spits_job_manager_new(int argc, const char *argv[],
     return reinterpret_cast<void*>(jm);
 }
 
-extern "C" int spits_job_manager_next_task(void *user_data, 
+extern "C" int spits_job_manager_next_task(void *user_data,
     spitspush_t push_task, spitsctx_t jmctx)
 {
     class spitz::job_manager *jm = reinterpret_cast
         <spitz::job_manager*>(user_data);
-    
+
     spitz::pusher task(push_task, jmctx);
     return jm->next_task(task) ? 1 : 0;
 }
@@ -180,7 +182,7 @@ extern "C" void spits_job_manager_finalize(void *user_data)
 {
     class spitz::job_manager *jm = reinterpret_cast
         <spitz::job_manager*>(user_data);
-    
+
     delete jm;
 }
 
@@ -190,16 +192,16 @@ extern "C" void *spits_worker_new(int argc, const char **argv)
     return reinterpret_cast<void*>(w);
 }
 
-extern "C" int spits_worker_run(void *user_data, const void* task, 
-    spitssize_t tasksz, spitspush_t push_result, 
+extern "C" int spits_worker_run(void *user_data, const void* task,
+    spitssize_t tasksz, spitspush_t push_result,
     spitsctx_t taskctx)
 {
     spitz::worker *w = reinterpret_cast
         <spitz::worker*>(user_data);
-    
+
     spitz::istream stask(task, tasksz);
     spitz::pusher result(push_result, taskctx);
-    
+
     return w->run(stask, result);
 }
 
@@ -207,7 +209,7 @@ extern "C" void spits_worker_finalize(void *user_data)
 {
     spitz::worker *w = reinterpret_cast
         <spitz::worker*>(user_data);
-    
+
     delete w;
 }
 
@@ -224,7 +226,7 @@ extern "C" int spits_committer_commit_pit(void *user_data,
 {
     spitz::committer *co = reinterpret_cast
         <spitz::committer*>(user_data);
-    
+
     spitz::istream sresult(result, resultsz);
     return co->commit_task(sresult);
 }
@@ -234,7 +236,7 @@ extern "C" int spits_committer_commit_job(void *user_data,
 {
     spitz::committer *co = reinterpret_cast
         <spitz::committer*>(user_data);
-    
+
     spitz::pusher final_result(push_final_result, jobctx);
     return co->commit_job(final_result);
 }
@@ -243,7 +245,7 @@ extern "C" void spits_committer_finalize(void *user_data)
 {
     spitz::committer *co = reinterpret_cast
         <spitz::committer*>(user_data);
-    
+
     delete co;
 }
 
@@ -256,7 +258,7 @@ extern "C" void spits_committer_finalize(void *user_data)
 #include <sstream>
 #include <stdint.h>
 
-static void spitz_debug_pusher(const void* pdata, 
+static void spitz_debug_pusher(const void* pdata,
     spitssize_t size, spitsctx_t ctx)
 {
     std::vector<uint8_t>* v = reinterpret_cast<std::vector<uint8_t>*>
@@ -268,79 +270,79 @@ static void spitz_debug_pusher(const void* pdata,
 
     v->push_back(1);
 
-    std::copy(reinterpret_cast<const uint8_t*>(pdata), 
-        reinterpret_cast<const uint8_t*>(pdata) + size, 
+    std::copy(reinterpret_cast<const uint8_t*>(pdata),
+        reinterpret_cast<const uint8_t*>(pdata) + size,
         std::back_inserter(*v));
 }
 
-static int spitz_debug_runner(int argc, const char** argv, 
-    const void* pjobinfo, spitssize_t jobinfosz, 
+static int spitz_debug_runner(int argc, const char** argv,
+    const void* pjobinfo, spitssize_t jobinfosz,
     const void** pfinal_result, spitssize_t* pfinal_resultsz)
 {
     void* jm = spits_job_manager_new(argc, argv, pjobinfo, jobinfosz);
     void* co = spits_committer_new(argc, argv, pjobinfo, jobinfosz);
     void* wk = spits_worker_new(argc, argv);
-    
+
     static int64_t jid = 0;
     int64_t tid = 0;
-    
+
     int r1 = 0, r2 = 0, r3 = 0;
-    
+
     std::vector<int8_t> task;
     std::vector<int8_t> result;
     std::vector<int8_t>* final_result = new std::vector<int8_t>();
-    
+
     while(true) {
         task.clear();
         std::cerr << "[SPITZ] Generating task " << tid << "..." << std::endl;
         if(!spits_job_manager_next_task(jm, spitz_debug_pusher, &task))
             break;
-        
+
         if (task.size() == 0) {
             std::cerr << "[SPITZ] Task manager didn't push a task!"
                 << std::endl;
             exit(1);
         }
-        
+
         result.clear();
         std::cerr << "[SPITZ] Executing task " << tid << "..." << std::endl;
-        r1 = spits_worker_run(wk, task.data()+1, task.size()-1, 
+        r1 = spits_worker_run(wk, task.data()+1, task.size()-1,
             spitz_debug_pusher, &result);
-        
+
         if (r1 != 0) {
-            std::cerr << "[SPITZ] Task " << tid << " failed to execute!" 
+            std::cerr << "[SPITZ] Task " << tid << " failed to execute!"
                 << std::endl;
             goto dump_task_and_exit;
         }
-        
+
         if (task.size() == 0) {
             std::cerr << "[SPITZ] Worker didn't push a result!"
                 << std::endl;
             goto dump_task_and_exit;
         }
-        
+
         std::cerr << "[SPITZ] Committing task " << tid << "..." << std::endl;
         r2 = spits_committer_commit_pit(co, result.data()+1, result.size()-1);
-        
+
         if (r2 != 0) {
-            std::cerr << "[SPITZ] Task " << tid << " failed to commit!" 
+            std::cerr << "[SPITZ] Task " << tid << " failed to commit!"
                 << std::endl;
             goto dump_result_and_exit;
         }
         tid++;
     }
     std::cerr << "[SPITZ] Finished processing tasks." << std::endl;
-    
+
     final_result->clear();
     std::cerr << "[SPITZ] Committing job " << jid << "..." << std::endl;
     r3 = spits_committer_commit_job(co, spitz_debug_pusher, final_result);
-    
+
     if (r3 != 0) {
-        std::cerr << "[SPITZ] Job " << jid << " failed to commit!" 
+        std::cerr << "[SPITZ] Job " << jid << " failed to commit!"
             << std::endl;
         exit(1);
     }
-    
+
     if (final_result->size() <= 1) {
         *pfinal_result = NULL;
         *pfinal_resultsz = 0;
@@ -348,45 +350,45 @@ static int spitz_debug_runner(int argc, const char** argv,
         *pfinal_result = final_result->data()+1;
         *pfinal_resultsz = final_result->size()-1;
     }
-    
+
     std::cerr << "[SPITZ] Finalizing task manager..." << std::endl;
     spits_job_manager_finalize(jm);
-    
+
     std::cerr << "[SPITZ] Finalizing committer..." << std::endl;
     spits_committer_finalize(co);
-    
+
     std::cerr << "[SPITZ] Finalizing worker..." << std::endl;
     spits_worker_finalize(wk);
-    
+
     std::cerr << "[SPITZ] Job " << jid << " completed." << std::endl;
     jid++;
-    
+
     return 0;
-    
+
 dump_result_and_exit:
     {
-        std::cerr << "[SPITZ] Generating result dump for task " 
+        std::cerr << "[SPITZ] Generating result dump for task "
             << tid << "..." << std::endl;
         std::stringstream ss;
         ss << "result-" << tid << ".dump";
         std::ofstream resfile(ss.str().c_str(), std::ofstream::binary);
-        resfile.write(reinterpret_cast<const char*>(result.data()+1), 
+        resfile.write(reinterpret_cast<const char*>(result.data()+1),
             result.size()-1);
         resfile.close();
-        std::cerr << "[SPITZ] Result dump generated as " << ss.str() << 
+        std::cerr << "[SPITZ] Result dump generated as " << ss.str() <<
             " [" << (result.size()-1) << " bytes]. " << std::endl;
     }
 dump_task_and_exit:
     {
-        std::cerr << "[SPITZ] Generating task dump for task " 
+        std::cerr << "[SPITZ] Generating task dump for task "
             << tid << "..." << std::endl;
         std::stringstream ss;
         ss << "task-" << tid << ".dump";
         std::ofstream taskfile(ss.str().c_str(), std::ofstream::binary);
-        taskfile.write(reinterpret_cast<const char*>(task.data()+1), 
+        taskfile.write(reinterpret_cast<const char*>(task.data()+1),
             task.size()-1);
         taskfile.close();
-        std::cerr << "[SPITZ] Task dump generated as " << ss.str() << 
+        std::cerr << "[SPITZ] Task dump generated as " << ss.str() <<
             " [" << (task.size()-1) << " bytes]. " << std::endl;
     }
     exit(1);

--- a/spitz-include/ccpp/spitz/stream.hpp
+++ b/spitz-include/ccpp/spitz/stream.hpp
@@ -4,22 +4,22 @@
  * Copyright (c) 2015 Caian Benedicto <caian@ggaunicamp.com>
  * Copyright (c) 2014 Ian Liu Rodrigues <ian.liu@ggaunicamp.com>
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy 
- * of this software and associated documentation files (the "Software"), to 
- * deal in the Software without restriction, including without limitation the 
- * rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in 
+ *
+ * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
 
@@ -37,12 +37,12 @@
 #include <algorithm>
 
 namespace spitz {
-    
-    class ostream 
+
+    class ostream
     {
     private:
         std::vector<char> pdata;
-        
+
         static uint64_t spitz_htonll(uint64_t x)
         {
             if (htons(1) == 1)
@@ -53,26 +53,26 @@ namespace spitz {
             uint64_t nhi = htonl(hi);
             return nhi << 32 | nlo;
         }
-        
+
         template<typename T> void push_back(const T& v)
         {
             size_t s = this->pdata.size();
             this->pdata.resize(s + sizeof(T));
             *reinterpret_cast<T*>(this->pdata.data() + s) = v;
         }
-        
+
         template<typename T> uint16_t hton16(const T& v)
         {
             const char* p = reinterpret_cast<const char*>(&v);
             return htons(*reinterpret_cast<const uint16_t*>(p));
         }
-        
+
         template<typename T> uint32_t hton32(const T& v)
         {
             const char* p = reinterpret_cast<const char*>(&v);
             return htonl(*reinterpret_cast<const uint32_t*>(p));
         }
-        
+
         template<typename T> uint64_t hton64(const T& v)
         {
             const char* p = reinterpret_cast<const char*>(&v);
@@ -81,7 +81,7 @@ namespace spitz {
 
     public:
         ostream() : pdata() { }
-        
+
         void write_bool(const bool& v) { push_back((char)(v ? 1 : 0)); }
         void write_char(const int8_t& v) { push_back(v); }
         void write_byte(const uint8_t& v) { push_back(v); }
@@ -94,18 +94,18 @@ namespace spitz {
         void write_longlong(const int64_t& v) { push_back(hton64(v)); }
         void write_ulonglong(const uint64_t& v) { push_back(hton64(v)); }
         void write_string(const std::string& v)
-        { 
+        {
             const char *p = v.c_str();
-            do { write_char(*p); } 
+            do { write_char(*p); }
             while (*p++);
         }
         void write_data(const void* pdata, size_t size)
         {
-            std::copy(reinterpret_cast<const char*>(pdata), 
-                reinterpret_cast<const char*>(pdata) + size, 
+            std::copy(reinterpret_cast<const char*>(pdata),
+                reinterpret_cast<const char*>(pdata) + size,
                 std::back_inserter(this->pdata));
         }
-        
+
         ostream& operator<<(const float& v)       { write_float(v); return *this; }
         ostream& operator<<(const double& v)      { write_double(v); return *this; }
         ostream& operator<<(const int8_t& v)      { write_char(v); return *this; }
@@ -119,23 +119,23 @@ namespace spitz {
         ostream& operator<<(const bool& v)        { write_bool(v); return *this; }
         ostream& operator<<(const std::string& v) { write_string(v); return *this; }
 
-        size_t pos() const 
+        size_t pos() const
         {
             return this->pdata.size();
         }
-        
+
         const void* data() const
         {
             return this->pdata.data();
         }
     };
-    
-    class istream 
+
+    class istream
     {
     private:
         const char* pdata;
         size_t sz, pos;
-        
+
         static uint64_t spitz_ntohll(uint64_t x)
         {
             if (ntohs(1) == 1)
@@ -146,7 +146,7 @@ namespace spitz {
             uint64_t nhi = htonl(hi);
             return nhi << 32 | nlo;
         }
-        
+
         char get1()
         {
             ensure_size(1);
@@ -178,7 +178,7 @@ namespace spitz {
             this->pos += 8;
             return spitz_ntohll(v);
         }
-        
+
         template<typename T> T get_as()
         {
             ensure_size(sizeof(T));
@@ -186,7 +186,7 @@ namespace spitz {
             this->pos += sizeof(T);
             return v;
         }
-        
+
         void ensure_size(size_t n)
         {
             if (this->sz - this->pos < n)
@@ -194,20 +194,20 @@ namespace spitz {
         }
 
     public:
-        istream() : 
-            pdata(reinterpret_cast<const char*>(0)), 
-            sz(0), 
-            pos(0) 
-        { 
+        istream() :
+            pdata(reinterpret_cast<const char*>(0)),
+            sz(0),
+            pos(0)
+        {
         }
-            
-        istream(const void *data, const size_t& size) : 
-            pdata(reinterpret_cast<const char*>(data)), 
-            sz(size), 
-            pos(0) 
-        { 
+
+        istream(const void *data, const size_t& size) :
+            pdata(reinterpret_cast<const char*>(data)),
+            sz(size),
+            pos(0)
+        {
         }
-        
+
         bool read_bool() { uint8_t v = get1(); return v ? true : false; }
         int8_t read_char() { return get1(); }
         uint8_t read_byte() { char v = get1(); return *((int8_t*)&v); }
@@ -220,7 +220,7 @@ namespace spitz {
         int64_t read_longlong() { uint64_t v = get8(); return *((int64_t*)(char*)&v); }
         uint64_t read_ulonglong() { return get8(); }
         std::string read_string()
-        { 
+        {
             std::stringstream ss;
             char c;
             while((c = read_char()))
@@ -230,10 +230,10 @@ namespace spitz {
         void read_data(void* pdata, size_t size)
         {
             ensure_size(size);
-            
-            std::copy(this->pdata + this->pos, this->pdata + this->pos + size, 
+
+            std::copy(this->pdata + this->pos, this->pdata + this->pos + size,
                 reinterpret_cast<char*>(pdata));
-            
+
             this->pos += size;
         }
 
@@ -250,12 +250,12 @@ namespace spitz {
         istream& operator>>(bool& v)        { v = read_bool(); return *this; }
         istream& operator>>(std::string& v) { v = read_string(); return *this; }
 
-        size_t size() const 
+        size_t size() const
         {
             return this->sz;
         }
-        
-        bool has_data() const 
+
+        bool has_data() const
         {
             return this->pos < this->sz;
         }

--- a/spitz-python/jm.py
+++ b/spitz-python/jm.py
@@ -31,7 +31,7 @@ from libspitz import log_lines
 from libspitz import PerfModule
 
 import Args
-import sys, threading, os, time, ctypes, logging, struct, threading, traceback
+import sys, threading, os, time, logging, struct, traceback
 
 # Global configuration parameters
 jm_killtms = None # Kill task managers after execution

--- a/spitz-python/jm.py
+++ b/spitz-python/jm.py
@@ -4,22 +4,22 @@
 #
 # Copyright (c) 2015 Caian Benedicto <caian@ggaunicamp.com>
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy 
-# of this software and associated documentation files (the "Software"), to 
-# deal in the Software without restriction, including without limitation the 
-# rights to use, copy, modify, merge, publish, distribute, sublicense, 
-# and/or sell copies of the Software, and to permit persons to whom the 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following conditions:
-# 
-# The above copyright notice and this permission notice shall be included in 
+#
+# The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
 from libspitz import JobBinary, SimpleEndpoint
@@ -213,7 +213,7 @@ def load_tm_list_from_dir(dirname = None):
         dirname = 'nodes'
 
     logging.debug('Loading task manager list from %s...' % (dirname,))
-    
+
     tms = {}
 
     # Read all files
@@ -224,7 +224,7 @@ def load_tm_list_from_dir(dirname = None):
                 continue
             tms.update(load_tm_list_from_file(f))
     except:
-        logging.warning('Error loading the list of task ' + 
+        logging.warning('Error loading the list of task ' +
             'managers from directory!')
         return {}
 
@@ -248,7 +248,7 @@ def setup_endpoint_for_pushing(e):
         e.Open(jm_conn_timeout)
     except:
         # Problem connecting to the task manager
-        # Because this is a connection event, 
+        # Because this is a connection event,
         # make it a debug rather than a warning
         logging.debug('Error connecting to task manager at %s:%d!',
             e.address, e.port)
@@ -305,7 +305,7 @@ def setup_endpoint_for_pulling(e):
         e.Open(jm_conn_timeout)
     except:
         # Problem connecting to the task manager
-        # Because this is a connection event, 
+        # Because this is a connection event,
         # make it a debug rather than a warning
         logging.debug('Error connecting to task manager at %s:%d!',
             e.address, e.port)
@@ -356,17 +356,17 @@ def push_tasks(job, runid, jm, tm, taskid, task, tasklist, completed):
             # Only get a task if the last one was already sent
             newtaskid = taskid + 1
             r1, newtask, ctx = job.spits_job_manager_next_task(jm, newtaskid)
-            
+
             # Exit if done
             if r1 == 0:
                 return (True, 0, None, sent)
-            
+
             if newtask == None:
                 logging.error('Task %d was not pushed!', newtaskid)
                 return (False, taskid, task, sent)
 
             if ctx != newtaskid:
-                logging.error('Context verification failed for task %d!', 
+                logging.error('Context verification failed for task %d!',
                     newtaskid)
                 return (False, taskid, task, sent)
 
@@ -375,7 +375,7 @@ def push_tasks(job, runid, jm, tm, taskid, task, tasklist, completed):
             task = newtask[0]
             tasklist[taskid] = (0, task)
 
-            logging.debug('Generated task %d with payload size of %d bytes.', 
+            logging.debug('Generated task %d with payload size of %d bytes.',
                 taskid, len(task) if task != None else 0)
 
         try:
@@ -465,12 +465,12 @@ def commit_tasks(job, runid, co, tm, tasklist, completed):
                         'worker returned %d!', taskid, r)
 
             if taskrunid < runid:
-                logging.debug('The task %d is from the previous run %d ' + 
+                logging.debug('The task %d is from the previous run %d ' +
                     'and will be ignored!', taskid, taskrunid)
                 continue
 
             if taskrunid > runid:
-                logging.error('Received task %d from a future run %d!', 
+                logging.error('Received task %d from a future run %d!',
                     taskid, taskrunid)
                 continue
 
@@ -572,7 +572,7 @@ def heartbeat(finished):
                 tm.Open(jm_heart_timeout)
             except:
                 # Problem connecting to the task manager
-                # Because this is a connection event, 
+                # Because this is a connection event,
                 # make it a debug rather than a warning
                 logging.debug('Error connecting to task manager at %s:%d!',
                     tm.address, tm.port)
@@ -646,7 +646,7 @@ def jobmanager(argv, job, runid, jm, tasklist, completed):
 
                 # Task pushing loop
                 memstat.stats()
-                finished, taskid, task, sent = push_tasks(job, runid, jm, 
+                finished, taskid, task, sent = push_tasks(job, runid, jm,
                     tm, taskid, task, tasklist, completed[0] == 1)
 
                 # Add the sent tasks to the sumission list

--- a/spitz-python/libspitz/Blob.py
+++ b/spitz-python/libspitz/Blob.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 Caian Benedicto <caian@ggaunicamp.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+import ctypes
+
+class Blob(object):
+    """Class encapsulating large data moving inside the runtime"""
+
+    def __init__(self, data_size=0, data_pointer=None, copy=False):
+        """Construct a new object given a pointer to the data and size.
+           If no data pointer is provided then the memory is allocated
+           internally."""
+
+        if data_size < 0:
+            raise Exception()
+
+        self._data_size = data_size
+
+        if copy and (data_pointer is None):
+            raise Exception()
+
+        will_allocate = (data_pointer is None) or copy
+
+        if will_allocate and data_size > 0:
+            # Allocate the data internally
+            self._inner_data = (ctypes.c_byte * data_size)()
+            self._data_pointer = ctypes.cast(self._inner_data,
+                ctypes.c_void_p)
+            if copy:
+                # Copy data
+                ctypes.memmove(self._data_pointer,
+                    data_pointer, data_size)
+        else:
+            # Keep the input data
+            self._inner_data = None
+            self._data_pointer = data_pointer
+
+    def get_pointer(self):
+        """Get the pointer to the stored data."""
+        return self._data_pointer
+
+    def get_size(self):
+        """Get the size in bytes of the stored data."""
+        return self._data_size

--- a/spitz-python/libspitz/JobBinary.py
+++ b/spitz-python/libspitz/JobBinary.py
@@ -4,22 +4,22 @@
 #
 # Copyright (c) 2015 Caian Benedicto <caian@ggaunicamp.com>
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy 
-# of this software and associated documentation files (the "Software"), to 
-# deal in the Software without restriction, including without limitation the 
-# rights to use, copy, modify, merge, publish, distribute, sublicense, 
-# and/or sell copies of the Software, and to permit persons to whom the 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following conditions:
-# 
-# The above copyright notice and this permission notice shall be included in 
+#
+# The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
 import ctypes, os, struct, sys, logging

--- a/spitz-python/libspitz/JobBinary.py
+++ b/spitz-python/libspitz/JobBinary.py
@@ -22,7 +22,9 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import ctypes, os, struct, sys, logging
+import ctypes, os, struct, sys
+
+from libspitz import Blob, Pointer
 
 # TODO try-except around C calls
 
@@ -34,17 +36,6 @@ class JobBinary(object):
         filename = os.path.realpath(filename)
         self.filename = filename
         self.module = ctypes.CDLL(filename)
-
-        # Create the return type for the *new functions, otherwise
-        # it will assume int as return instead of void*
-        rettype_new = ctypes.c_void_p
-
-        self._spits_job_manager_new = self.module.spits_job_manager_new
-        self._spits_job_manager_new.restype = rettype_new;
-
-        self.module.spits_job_manager_new.restype = rettype_new;
-        self.module.spits_worker_new.restype = rettype_new;
-        self.module.spits_committer_new.restype = rettype_new;
 
         # Create the c function for the runner callback
         self.crunner = ctypes.CFUNCTYPE(
@@ -62,6 +53,97 @@ class JobBinary(object):
             ctypes.c_void_p,
             ctypes.c_longlong,
             ctypes.c_void_p)
+
+        c_context = ctypes.c_void_p
+
+        # Create the return type for some functions, otherwise
+        # ctypes will assume int. Also create the arguments
+        # otherwise ctypes may assume wrong
+
+        # Do not fail if any method cannot be found because
+        # this code is shared between job manager and task managers,
+        # so different agents may use different binaries with
+        # different parts of the interface exposed
+
+        # Main
+
+        self.try_init_method('spits_main', ctypes.c_int, [
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_char_p),
+            self.crunner
+        ])
+
+        # Job Manager
+
+        self.try_init_method('spits_job_manager_new', ctypes.c_void_p, [
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_char_p),
+            ctypes.c_void_p,
+            ctypes.c_longlong
+        ])
+
+        self.try_init_method('spits_job_manager_next_task', ctypes.c_int, [
+            ctypes.c_void_p,
+            self.cpusher,
+            c_context
+        ])
+
+        self.try_init_method('spits_job_manager_finalize', None, [
+            ctypes.c_void_p
+        ])
+
+        # Worker
+
+        self.try_init_method('spits_worker_new', ctypes.c_void_p, [
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_char_p)
+        ])
+
+        self.try_init_method('spits_worker_run', ctypes.c_int, [
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_longlong,
+            self.cpusher,
+            c_context
+        ])
+
+        self.try_init_method('spits_worker_finalize', None, [
+            ctypes.c_void_p
+        ])
+
+        # Committer
+
+        self.try_init_method('spits_committer_new', ctypes.c_void_p, [
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_char_p),
+            ctypes.c_void_p,
+            ctypes.c_longlong
+        ])
+
+        self.try_init_method('spits_committer_commit_pit', ctypes.c_int, [
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_longlong
+        ])
+
+        self.try_init_method('spits_committer_commit_job', ctypes.c_int, [
+            ctypes.c_void_p,
+            self.cpusher,
+            c_context
+        ])
+
+        self.try_init_method('spits_committer_finalize', None, [
+                ctypes.c_void_p
+        ])
+
+    def try_init_method(self, name, restype, argtypes):
+        """Set the specified format for a method in the module,
+        if it exists. Return true if it does exist."""
+        if not hasattr(self.module, name):
+            return False
+        method = getattr(self.module, name)
+        method.restype = restype
+        method.argtypes = argtypes
 
     def c_argv(self, argv):
         # Encode the string to byte array
@@ -102,20 +184,23 @@ class JobBinary(object):
     def to_py_array(self, v, sz):
         v = ctypes.cast(v, ctypes.POINTER(ctypes.c_byte))
         return self.bytes(v[0:sz])
-        
+
     def spits_main(self, argv, runner):
         # Call the runner if the job does not have an initializer
         if not hasattr(self.module, 'spits_main'):
             return runner(argv, None)
 
         # Create an inner converter for the callback
-        def run(argc, argv, jobinfo, jobinfosize, data, size):
+        def run(argc, argv, pjobinfo, jobinfosize, data, size):
             # Convert argc/argv back to a string list
             pargv = [argv[i].decode('utf8') for i in range(0, argc)]
-            pjobinfo = self.to_py_array(jobinfo, jobinfosize)
+            # Create a data blob without copying the buffer because
+            # the method will lock the runner until it ends, so the
+            # pointer is always valid
+            bjobinfo = Blob(jobinfosize, pjobinfo)
 
             # Run the runner code
-            r, pdata = runner(pargv, pjobinfo)
+            r, pdata = runner(pargv, bjobinfo)
 
             # Convert the data result to a C pointer/size
             if pdata == None:
@@ -139,105 +224,106 @@ class JobBinary(object):
     def spits_job_manager_new(self, argv, jobinfo):
         # Cast the C arguments
         cargc, cargv = self.c_argv(argv)
-        cjobinfo, cjobinfosz = self.to_c_array(jobinfo)
-
-        return ctypes.c_void_p(self._spits_job_manager_new(cargc, cargv, 
-            cjobinfo, cjobinfosz))
+        # Call the native method casting the result to a simple pointer
+        return Pointer(self.module.spits_job_manager_new(cargc,
+            cargv, jobinfo.get_pointer(), jobinfo.get_size()))
 
     def spits_job_manager_next_task(self, user_data, jmctx):
         res = [None, None, None]
-        
+        # Get the native pointer to the user data
+        p_user_data = user_data.get_value()
         # Create an inner converter for the callback
         def push(ctask, ctasksz, ctx):
-            # Thanks to python closures, the context is not 
+            # Thanks to python closures, the context is not
             # necessary, in any case, check for correctness
             res[1] = (self.to_py_array(ctask, ctasksz),)
             res[2] = ctx
-
         # Get the next task
-        res[0] = self.module.spits_job_manager_next_task(user_data,
-            self.cpusher(push), ctypes.c_void_p(jmctx))
-
+        res[0] = self.module.spits_job_manager_next_task(p_user_data,
+            self.cpusher(push), jmctx)
+        # Return the pushed data along with the return code of the method
         return res
 
     def spits_job_manager_finalize(self, user_data):
+        # Get the native pointer to the user data
+        p_user_data = user_data.get_value()
         # Optional function
         if not hasattr(self.module, 'spits_job_manager_finalize'):
             return
-
         # Is expected that the framework will not mess with the
-        # value inside user_data do its ctype will remain unchanged
-        return self.module.spits_job_manager_finalize(user_data)
+        # value inside user_data so its ctype will remain unchanged
+        return self.module.spits_job_manager_finalize(p_user_data)
 
     def spits_worker_new(self, argv):
         # Cast the C arguments
         cargc, cargv = self.c_argv(argv)
-
-        return ctypes.c_void_p(self.module.spits_worker_new(cargc, cargv))
+        # Call the native method casting the result to a simple pointer
+        return Pointer(self.module.spits_worker_new(cargc, cargv))
 
     def spits_worker_run(self, user_data, task, taskctx):
         res = [None, None, None]
-
+        # Get the native pointer to the user data
+        p_user_data = user_data.get_value()
         # Create the pointer to task and task size
         ctask, ctasksz = self.to_c_array(task)
-
         # Create an inner converter for the callback
         def push(cres, cressz, ctx):
-            # Thanks to python closures, the context is not 
+            # Thanks to python closures, the context is not
             # necessary, in any case, check for correctness
             res[1] = (self.to_py_array(cres, cressz),)
             res[2] = ctx
-
         # Run the task
-        res[0] = self.module.spits_worker_run(user_data, ctask, ctasksz, 
-            self.cpusher(push), ctypes.c_void_p(taskctx))
-
+        res[0] = self.module.spits_worker_run(p_user_data, ctask,
+            ctasksz, self.cpusher(push), taskctx)
+        # Return the pushed data along with the return code of the method
         return res
 
     def spits_worker_finalize(self, user_data):
+        # Get the native pointer to the user data
+        p_user_data = user_data.get_value()
         # Optional function
         if not hasattr(self.module, 'spits_worker_finalize'):
             return
-
         # Is expected that the framework will not mess with the
-        # value inside user_data do its ctype will remain unchanged
-        return self.module.spits_worker_finalize(user_data)
+        # value inside user_data so its ctype will remain unchanged
+        return self.module.spits_worker_finalize(p_user_data)
 
     def spits_committer_new(self, argv, jobinfo):
         # Cast the C arguments
         cargc, cargv = self.c_argv(argv)
-        cjobinfo, cjobinfosz = self.to_c_array(jobinfo)
-        
-        return ctypes.c_void_p(self.module.spits_committer_new(cargc, cargv, 
-            cjobinfo, cjobinfosz))
+        # Call the native method casting the result to a simple pointer
+        return Pointer(self.module.spits_committer_new(cargc, cargv,
+            jobinfo.get_pointer(), jobinfo.get_size()))
 
     def spits_committer_commit_pit(self, user_data, result):
         # Create the pointer to result and result size
         cres, cressz = self.to_c_array(result)
-
-        return self.module.spits_committer_commit_pit(user_data, cres, cressz)
+        # Get the native pointer to the user data
+        p_user_data = user_data.get_value()
+        return self.module.spits_committer_commit_pit(p_user_data, cres, cressz)
 
     def spits_committer_commit_job(self, user_data, jobctx):
         fres = [None, None, None]
-
+        # Get the native pointer to the user data
+        p_user_data = user_data.get_value()
         # Create an inner converter for the callback
         def push(cfres, cfressz, ctx):
-            # Thanks to python closures, the context is not 
+            # Thanks to python closures, the context is not
             # necessary, in any case, check for correctness
             fres[1] = (self.to_py_array(cfres, cfressz),)
             fres[2] = ctx
-
         # Commit job and get the final result
-        fres[0] = self.module.spits_committer_commit_job(user_data,
-            self.cpusher(push), ctypes.c_void_p(jobctx))
-
+        fres[0] = self.module.spits_committer_commit_job(p_user_data,
+            self.cpusher(push), jobctx)
+        # Return the pushed data along with the return code of the method
         return fres
 
     def spits_committer_finalize(self, user_data):
+        # Get the native pointer to the user data
+        p_user_data = user_data.get_value()
         # Optional function
         if not hasattr(self.module, 'spits_committer_finalize'):
             return
-
         # Is expected that the framework will not mess with the
-        # value inside user_data do its ctype will remain unchanged
-        return self.module.spits_committer_finalize(user_data)
+        # value inside user_data so its ctype will remain unchanged
+        return self.module.spits_committer_finalize(p_user_data)

--- a/spitz-python/libspitz/Pointer.py
+++ b/spitz-python/libspitz/Pointer.py
@@ -2,7 +2,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 Caian Benedicto <caian@ggaunicamp.com>
+# Copyright (c) 2018 Caian Benedicto <caian@ggaunicamp.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -22,24 +22,15 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-from .LogUtils import *
+import ctypes
 
-from .Blob import Blob
-from .Pointer import Pointer
-from .JobBinary import JobBinary
+class Pointer(object):
+    """Class encapsulating a pointer to a region of memory"""
 
-from .Endpoint import Endpoint
-from .SimpleEndpoint import SimpleEndpoint
-from .ClientEndpoint import ClientEndpoint
+    def __init__(self, data_pointer=None):
+        """Construct a new object given a pointer to the data."""
+        self._data_pointer = ctypes.c_void_p(data_pointer)
 
-from .Listener import Listener
-from .TaskPool import TaskPool
-from .Timeout import timeout
-from .PerfModule import PerfModule
-from .UIDUtils import make_uid
-
-def main():
-    pass
-
-if __name__ == '__main__':
-    main()
+    def get_value(self):
+        """Get the pointer to the stored data."""
+        return self._data_pointer

--- a/spitz-python/libspitz/__init__.py
+++ b/spitz-python/libspitz/__init__.py
@@ -4,22 +4,22 @@
 #
 # Copyright (c) 2015 Caian Benedicto <caian@ggaunicamp.com>
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy 
-# of this software and associated documentation files (the "Software"), to 
-# deal in the Software without restriction, including without limitation the 
-# rights to use, copy, modify, merge, publish, distribute, sublicense, 
-# and/or sell copies of the Software, and to permit persons to whom the 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following conditions:
-# 
-# The above copyright notice and this permission notice shall be included in 
+#
+# The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
 from .LogUtils import *


### PR DESCRIPTION
Fixes #2 by encapsulating ctype pointers when passing `jobinfo` from `spits_main` to `job manager` and `committer`